### PR TITLE
Make bolus snooze suppress low-temps at mealtime

### DIFF
--- a/bin/iob.js
+++ b/bin/iob.js
@@ -75,9 +75,9 @@ function iobTotal(treatments, time) {
             var tIOB = iobCalc(treatment, time, dia);
             if (tIOB && tIOB.iobContrib) iob += tIOB.iobContrib;
             if (tIOB && tIOB.activityContrib) activity += tIOB.activityContrib;
-            // keep track of bolus IOB separately for snoozes, but decay it twice as fast`
+            // keep track of bolus IOB separately for snoozes, but decay it three times as fast
             if (treatment.insulin >= 0.2 && treatment.started_at) {
-                var bIOB = iobCalc(treatment, time, dia/2)
+                var bIOB = iobCalc(treatment, time, dia/3)
                 //console.log(treatment);
                 //console.log(bIOB);
                 if (bIOB && bIOB.iobContrib) bolusiob += bIOB.iobContrib;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaps-js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "openaps js plugins",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
To address https://github.com/openaps/openaps-js/issues/26 and make openaps respond a little bit more after an hour or two, I think we should make bolus snooze window 1.5x as big initially to avoid low-temping at mealtimes, but decay 1.5 times as fast (3x instead of 2x net iob).
